### PR TITLE
Reference meta-balena-common

### DIFF
--- a/layers/meta-balena-qemu/conf/samples/bblayers.conf.sample
+++ b/layers/meta-balena-qemu/conf/samples/bblayers.conf.sample
@@ -12,7 +12,7 @@ BBLAYERS ?= " \
     ${TOPDIR}/../layers/meta-openembedded/meta-filesystems \
     ${TOPDIR}/../layers/meta-openembedded/meta-networking \
     ${TOPDIR}/../layers/meta-openembedded/meta-python \
-    ${TOPDIR}/../layers/meta-balena/meta-resin-common \
+    ${TOPDIR}/../layers/meta-balena/meta-balena-common \
     ${TOPDIR}/../layers/meta-balena/meta-resin-sumo \
     ${TOPDIR}/../layers/meta-balena-qemu \
     ${TOPDIR}/../layers/meta-rust \


### PR DESCRIPTION
After changes in meta-balena that update our go version, this confuses
the build with references to the old meta-resin-common.

Signed-off-by: Robert Günzler <robertg@balena.io>