### PR TITLE
Change test app name

### DIFF
--- a/tests/start.sh
+++ b/tests/start.sh
@@ -27,7 +27,7 @@ docker run --rm -t -v ${WORKSPACE}/tests/autohat:/autohat --privileged \
     --env email=${RESIN_EMAIL} \
     --env password=${RESIN_PASSWORD} \
     --env device_type=${MACHINE} \
-    --env application_name=${MACHINE//-} \
+    --env application_name=${MACHINE//-}-test-app \
     --env image=/autohat/resin.img \
     --privileged \
     $AUTOHAT_IMAGE robot --exitonerror --exitonfailure -d /autohat /autohat/qemu.robot


### PR DESCRIPTION
A workaround for a problem with creating an application with CLI.
qemu86 app seems to be registered as a public one, and older CLI versions
fail to create app with such a name even though the app name has to be unique
in the scope of the user only. So the workaround is to change the app name
because we cannot update the CLI version atm.