### PR TITLE
resin-image: Don't define UBOOT_MACHINE

### DIFF
--- a/layers/meta-balena-qemu/recipes-core/images/resin-image.bbappend
+++ b/layers/meta-balena-qemu/recipes-core/images/resin-image.bbappend
@@ -33,3 +33,8 @@ deploy_image_in_bundle() {
 }
 IMAGE_POSTPROCESS_COMMAND_append_qemux86 = " deploy_image_in_bundle; "
 IMAGE_POSTPROCESS_COMMAND_append_qemux86-64 = " deploy_image_in_bundle; "
+
+# Bootloader is GRUB
+python () {
+        d.delVar("UBOOT_MACHINE")
+}


### PR DESCRIPTION
Grub is used for the qemu device type,
there's no reason to keep uboot_machine.

Changelog-entry: resin-image: Don't define UBOOT_MACHINE
Signed-off-by: Alexandru Costache <alexandru@balena.io>